### PR TITLE
TASK: Set default lifetime for cachebuster identifier cache to 5 seconds in development context

### DIFF
--- a/Configuration/Development/Caches.yaml
+++ b/Configuration/Development/Caches.yaml
@@ -1,0 +1,4 @@
+
+Sitegeist_KlarSchiff_CacheBusterIdentifierCache:
+  backendOptions:
+    defaultLifetime: 5


### PR DESCRIPTION
This makes regular flushing of this cache in development obsolete.