### PR TITLE
BUGFIX: Fix version constraint for Flow 7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "description": "Flow Package to avoid browser caching for updated resources",
     "license": "GPL-3.0+",
     "require": {
-        "neos/flow": "~4.0 || ~5.0 || ~6.0 || 7.0 || dev-master"
+        "neos/flow": "~4.0 || ~5.0 || ~6.0 || ~7.0 || dev-master"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Before, only version 7.0.0 could be installed, with this change all upcoming 7.0 releases are installable